### PR TITLE
Setup project for inclusion in dotty-community-build.

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rewrites = [ExplicitImplicit, ProcedureSyntax]
+imports.organize = false
+imports.removeUnused = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,8 @@
-sudo: false
-
 language: scala
-
-scala:
-  - 2.11.8
-  - 2.10.6
-
-jdk:
-  - oraclejdk7
-
-matrix:
-  include:
-  - scala: 2.12.0
-    jdk: oraclejdk8
-
-before_install:
-  - export PATH=${PATH}:./vendor/bundle
-
-install:
-  - rvm use 2.2.3 --install --fuzzy
-  - gem update --system
-  - gem install sass
-  - gem install jekyll -v 3.2.1
-
-cache:
-  directories:
-  - $HOME/.sbt/0.13/dependency
-  - $HOME/.sbt/boot/scala*
-  - $HOME/.sbt/launchers
-  - $HOME/.ivy2/cache
-  - $HOME/.nvm
-
 script:
-  - ./sbt ++$TRAVIS_SCALA_VERSION clean coreJS/test lawsJS/test
-  - ./sbt ++$TRAVIS_SCALA_VERSION clean coverage coreJVM/test lawsJVM/test coverageReport mimaReportBinaryIssues
-  - ./sbt ++$TRAVIS_SCALA_VERSION docs/makeMicrosite
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#spire-math"
-    on_success: change
-    on_failure: always
+  - sbt coreJVM/compile "last coreJVM/compile:compileIncremental"
+jdk:
+  - oraclejdk8
+env:
+  matrix:
+    - COMPILERVERSION=0.1.1-20170409-7294180-NIGHTLY

--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,13 @@ lazy val core = crossProject
     "org.scalatest" %%% "scalatest" % scalaTestVersion % "test"))
   .settings(algebraSettings: _*)
   .settings(sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.gen).taskValue)
+  .jvmConfigure(
+    _.settings(
+      scalaVersion := dottyLatestNightlyBuild.get,
+      scalacOptions := Seq("-language:Scala2")
+    )
+    .enablePlugins(DottyPlugin)
+  )
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js

--- a/core/src/main/scala/algebra/instances/byte.scala
+++ b/core/src/main/scala/algebra/instances/byte.scala
@@ -7,7 +7,7 @@ import algebra.ring._
 package object byte extends ByteInstances
 
 trait ByteInstances extends cats.kernel.instances.ByteInstances {
-  implicit val byteAlgebra = new ByteAlgebra
+  implicit val byteAlgebra: ByteAlgebra = new ByteAlgebra
 
   val ByteMinMaxLattice: BoundedDistributiveLattice[Byte] =
     BoundedDistributiveLattice.minMax[Byte](Byte.MinValue, Byte.MaxValue)

--- a/project/dotty-plugins.sbt
+++ b/project/dotty-plugins.sbt
@@ -1,0 +1,5 @@
+resolvers += Resolver.sonatypeRepo("releases")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.3.2")
+
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.0-RC2")


### PR DESCRIPTION
- Add sbt-dotty and configure to use latest nightly version.
- Add sbt-scalafix, scalafix added a type annotation for ByteAlgebra,
  which was the only reported error by dotty.
- Setup travis CI.